### PR TITLE
feat: add share --link mode with server-side allowlist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,13 +36,14 @@
 ```
 server.js              # Express 服务端：配对、鉴权、文件/文本 API、管理接口
 pin.js                 # 本地 CLI：生成 PIN、查看/撤销已配对设备
-share.js               # 本地 CLI：复制文件到共享目录、列出/清空共享文件
+share.js               # 本地 CLI：复制文件到共享目录、软链接分享(--link)、列出/清空共享文件
 public/
   index.html           # 单页前端
   app.js               # 浏览器端逻辑：配对、文件浏览/下载、文本收发
 lib/
   cloud-storage.js     # 云存储抽象：R2/Qiniu 上传、Presigned URL、配额清理
   chunked-aead.js      # 流式分块加密格式实现
+  shared-links.js      # 软链接分享白名单(data/shared-links.json)读写与路径判断
 syncd_client/
   __init__.py          # Python 包入口
   cli.py               # Python 轮询下载客户端完整实现

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ curl http://127.0.0.1:21891/healthz
 node share.js file1.pdf dir1 another.txt
 ```
 
+以符号链接方式共享（不复制文件，服务端只放行这些显式登记过的链接）：
+
+```bash
+node share.js --link /path/to/file1.pdf /path/to/dir1
+```
+
+链接项不会自动上传到云存储。跨平台注意：Linux/macOS 直接创建符号链接；Windows 上目录使用 junction（无需管理员权限），文件符号链接需要管理员权限或开发者模式，若无权限请改用上面的复制模式。
+
 查看当前共享文件：
 
 ```bash

--- a/lib/shared-links.js
+++ b/lib/shared-links.js
@@ -1,0 +1,120 @@
+'use strict';
+// 已登记软链接白名单(data/shared-links.json)的读写与判断工具
+// share.js --link 写入(原子写),server.js 读取(带 mtime 缓存)
+const fs = require('fs');
+const path = require('path');
+
+const REGISTRY_FILE_NAME = 'shared-links.json';
+
+function getRegistryPath(dataDir) {
+  return path.join(dataDir, REGISTRY_FILE_NAME);
+}
+
+// 链接名只允许 sharedDir 顶层的 basename,不得含路径分隔符
+function isValidLinkName(name) {
+  if (typeof name !== 'string' || !name) return false;
+  if (name === '.' || name === '..') return false;
+  if (name.includes('/') || name.includes('\\')) return false;
+  return true;
+}
+
+// 路径比较跨平台规范化:win32 下统一转小写(调用方需先走 realpath 再比较)
+function normalizePathForCompare(candidate) {
+  if (typeof candidate !== 'string') return '';
+  return process.platform === 'win32' ? candidate.toLowerCase() : candidate;
+}
+
+// 过滤非法条目:链接名必须是顶层 basename,目标必须是绝对路径 realpath
+function sanitizeRegistry(raw) {
+  const registry = {};
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return registry;
+  for (const [name, target] of Object.entries(raw)) {
+    if (!isValidLinkName(name)) continue;
+    if (typeof target !== 'string' || !path.isAbsolute(target)) continue;
+    registry[name] = target;
+  }
+  return registry;
+}
+
+// 读取登记文件;文件缺失或损坏时视为空登记
+function loadRegistry(dataDir) {
+  try {
+    const filePath = getRegistryPath(dataDir);
+    if (!fs.existsSync(filePath)) return {};
+    return sanitizeRegistry(JSON.parse(fs.readFileSync(filePath, 'utf8')));
+  } catch {
+    return {};
+  }
+}
+
+// 原子写:临时文件 + rename
+function saveRegistryAtomic(dataDir, registry) {
+  fs.mkdirSync(dataDir, { recursive: true });
+  const filePath = getRegistryPath(dataDir);
+  const tempPath = `${filePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tempPath, JSON.stringify(sanitizeRegistry(registry), null, 2));
+  fs.renameSync(tempPath, filePath);
+}
+
+// server.js 用:带 mtime 缓存的登记读取器,文件变化时自动重载
+function createCachedRegistryReader(dataDir) {
+  const filePath = getRegistryPath(dataDir);
+  let cachedMtimeMs = -1;
+  let cachedRegistry = {};
+  return function readRegistry() {
+    let stat = null;
+    try {
+      stat = fs.statSync(filePath);
+    } catch {
+      stat = null;
+    }
+    if (!stat) {
+      if (cachedMtimeMs !== 0) {
+        cachedMtimeMs = 0;
+        cachedRegistry = {};
+      }
+      return cachedRegistry;
+    }
+    if (stat.mtimeMs !== cachedMtimeMs) {
+      cachedMtimeMs = stat.mtimeMs;
+      cachedRegistry = loadRegistry(dataDir);
+    }
+    return cachedRegistry;
+  };
+}
+
+// 按顶层名字查登记目标(win32 下名字比较不区分大小写)
+function getRegisteredTarget(registry, name) {
+  if (!isValidLinkName(name) || !registry) return null;
+  if (Object.prototype.hasOwnProperty.call(registry, name)) return registry[name];
+  if (process.platform === 'win32') {
+    const lower = name.toLowerCase();
+    for (const [key, target] of Object.entries(registry)) {
+      if (key.toLowerCase() === lower) return target;
+    }
+  }
+  return null;
+}
+
+// 判断某个 realpath 是否等于登记目标或位于其内部(目录链接的子路径要允许)
+function isRealPathWithinTarget(realPath, target) {
+  if (!realPath || !target) return false;
+  const from = normalizePathForCompare(path.resolve(target));
+  const to = normalizePathForCompare(path.resolve(realPath));
+  if (from === to) return true;
+  const relative = path.relative(from, to);
+  return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+module.exports = {
+  REGISTRY_FILE_NAME,
+  getRegistryPath,
+  isValidLinkName,
+  normalizePathForCompare,
+  sanitizeRegistry,
+  loadRegistry,
+  saveRegistryAtomic,
+  createCachedRegistryReader,
+  getRegisteredTarget,
+  isRealPathWithinTarget,
+};

--- a/scripts/integration-test.js
+++ b/scripts/integration-test.js
@@ -80,6 +80,22 @@ function decryptAesGcm(key, encrypted) {
   return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
 }
 
+// 单文件下载:body 为 AES-256-GCM 密流,末尾 16 字节为 tag,IV 在响应头
+async function downloadPlainFile(baseUrl, requestPath, masterKey, deviceId) {
+  const headers = buildAuthHeaders('GET', requestPath, Buffer.alloc(0), masterKey, deviceId);
+  const response = await fetch(`${baseUrl}${requestPath}`, { headers });
+  if (!response.ok) {
+    throw new Error(`GET ${requestPath} -> ${response.status}`);
+  }
+  const iv = Buffer.from(response.headers.get('x-encrypted-iv'), 'hex');
+  const body = Buffer.from(await response.arrayBuffer());
+  const tag = body.subarray(body.length - 16);
+  const ciphertext = body.subarray(0, body.length - 16);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', masterKey, iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
 function assertNoPlainRelayAccessKey(data, expectedKey) {
   const serialized = JSON.stringify(data);
   if (serialized.includes(expectedKey)) {
@@ -155,6 +171,32 @@ async function main() {
   fs.writeFileSync(path.join(sharedDir, 'alpha.txt'), 'hello alpha\n');
   fs.writeFileSync(path.join(sharedDir, 'docs', 'note.txt'), 'nested\n');
 
+  // 软链接分享夹具:在 shared 外准备文件/目录,以与 share.js --link 相同的方式创建链接并写登记
+  const externalDir = path.join(tempRoot, 'external');
+  fs.mkdirSync(path.join(externalDir, 'ext-dir'), { recursive: true });
+  fs.writeFileSync(path.join(externalDir, 'ext-file.txt'), 'linked external file\n');
+  fs.writeFileSync(path.join(externalDir, 'ext-dir', 'inner.txt'), 'linked inner\n');
+  fs.writeFileSync(path.join(externalDir, 'secret.txt'), 'unregistered secret\n');
+
+  let linksAvailable = true;
+  try {
+    const realFile = fs.realpathSync(path.join(externalDir, 'ext-file.txt'));
+    const realDir = fs.realpathSync(path.join(externalDir, 'ext-dir'));
+    const realSecret = fs.realpathSync(path.join(externalDir, 'secret.txt'));
+    fs.symlinkSync(realFile, path.join(sharedDir, 'linked-file.txt'), 'file');
+    fs.symlinkSync(realDir, path.join(sharedDir, 'linked-dir'), process.platform === 'win32' ? 'junction' : 'dir');
+    // 未登记的越界符号链接:必须保持不可见、不可下载
+    fs.symlinkSync(realSecret, path.join(sharedDir, 'secret-link.txt'), 'file');
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, 'shared-links.json'), JSON.stringify({
+      'linked-file.txt': realFile,
+      'linked-dir': realDir,
+    }, null, 2));
+  } catch (err) {
+    linksAvailable = false;
+    console.log(`Skipping shared-link cases (symlink unavailable: ${(err && err.code) || err})`);
+  }
+
   const port = await getFreePort();
   const logs = [];
   const child = spawn(path.resolve(__dirname, '..', 'start.sh'), [], {
@@ -225,6 +267,64 @@ async function main() {
     const listed = devices.devices.find((entry) => entry.id === deviceId);
     if (!listed || listed.name !== 'Integration Test') {
       throw new Error(`Device list missing paired device: ${JSON.stringify(devices)}`);
+    }
+
+    if (linksAvailable) {
+      // 文件列表:已登记链接可见,未登记符号链接不可见
+      const filesHeaders = buildAuthHeaders('GET', '/api/files', Buffer.alloc(0), masterKey, deviceId);
+      const filesResponse = await fetch(`${baseUrl}/api/files`, { headers: filesHeaders });
+      const filesPayload = await filesResponse.json();
+      if (!filesResponse.ok) {
+        throw new Error(`Unexpected /api/files response: ${JSON.stringify(filesPayload)}`);
+      }
+      const tree = JSON.parse(decryptAesGcm(masterKey, filesPayload.encrypted).toString('utf8'));
+      const entriesByName = new Map(tree.map((entry) => [entry.name, entry]));
+      if (entriesByName.get('linked-file.txt')?.type !== 'file') {
+        throw new Error(`Registered file link missing from file list: ${JSON.stringify(tree)}`);
+      }
+      if (entriesByName.get('linked-dir')?.type !== 'dir'
+        || entriesByName.get('linked-dir/inner.txt')?.type !== 'file') {
+        throw new Error(`Registered dir link missing from file list: ${JSON.stringify(tree)}`);
+      }
+      if (entriesByName.has('secret-link.txt')) {
+        throw new Error('Unregistered symlink must not appear in file list');
+      }
+
+      // 下载链接文件,内容必须与源一致
+      const linkedFileContent = await downloadPlainFile(baseUrl, '/api/files/linked-file.txt', masterKey, deviceId);
+      if (linkedFileContent.toString('utf8') !== 'linked external file\n') {
+        throw new Error(`Linked file content mismatch: ${JSON.stringify(linkedFileContent.toString('utf8'))}`);
+      }
+
+      // 链接目录内的文件也可下载
+      const linkedInnerContent = await downloadPlainFile(baseUrl, '/api/files/linked-dir/inner.txt', masterKey, deviceId);
+      if (linkedInnerContent.toString('utf8') !== 'linked inner\n') {
+        throw new Error(`Linked dir inner content mismatch: ${JSON.stringify(linkedInnerContent.toString('utf8'))}`);
+      }
+
+      // 未登记符号链接:下载必须被拒绝(越界防护照旧生效)
+      const secretHeaders = buildAuthHeaders('GET', '/api/files/secret-link.txt', Buffer.alloc(0), masterKey, deviceId);
+      const secretResponse = await fetch(`${baseUrl}/api/files/secret-link.txt`, { headers: secretHeaders });
+      if (![403, 404].includes(secretResponse.status)) {
+        throw new Error(`Expected unregistered symlink download to be rejected, got ${secretResponse.status}`);
+      }
+
+      // 已登记链接可正常打包下载(跟随内容)
+      const linkArchiveBody = Buffer.from(JSON.stringify({ paths: ['linked-dir'] }));
+      const linkArchiveResponse = await fetch(`${baseUrl}/api/archive`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...buildAuthHeaders('POST', '/api/archive', linkArchiveBody, masterKey, deviceId),
+        },
+        body: linkArchiveBody,
+      });
+      if (!linkArchiveResponse.ok) {
+        throw new Error(`Archive over registered link failed with ${linkArchiveResponse.status}`);
+      }
+      if ((await linkArchiveResponse.arrayBuffer()).byteLength === 0) {
+        throw new Error('Archive over registered link was empty');
+      }
     }
 
     const archiveBody = Buffer.from(JSON.stringify({ paths: ['alpha.txt', 'docs'] }));

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const tar = require('tar');
 const packageJson = require('./package.json');
 const storage = require('./lib/cloud-storage');
 const chunkedAead = require('./lib/chunked-aead');
+const sharedLinks = require('./lib/shared-links');
 
 const app = express();
 app.disable('x-powered-by');
@@ -107,6 +108,20 @@ const seenRequestNonces = new Map();
 const DATA_DIR = path.resolve(process.env.DATA_DIR || path.join(__dirname, 'data'));
 const STATE_FILE = path.join(DATA_DIR, 'state.json');
 const sharedDir = path.resolve(process.env.SHARED_DIR || path.join(__dirname, 'shared'));
+// 已登记软链接白名单(data/shared-links.json),带 mtime 缓存
+const readSharedLinkRegistry = sharedLinks.createCachedRegistryReader(DATA_DIR);
+
+function getRegisteredLinkTarget(topName) {
+  return sharedLinks.getRegisteredTarget(readSharedLinkRegistry(), topName);
+}
+
+// realpath 逃出 sharedDir 时,仅当第一段是已登记链接名且 realFullPath 在登记目标内才放行
+function isRegisteredLinkEscapeAllowed(normalizedRelPath, realFullPath) {
+  const topName = String(normalizedRelPath || '').split('/')[0];
+  const target = getRegisteredLinkTarget(topName);
+  if (!target) return false;
+  return sharedLinks.isRealPathWithinTarget(realFullPath, target);
+}
 const repoSharedSourceDir = path.resolve(path.join(__dirname, 'shared'));
 const HIDDEN_SHARED_RELATIVE_PATHS = new Set(
   sharedDir === repoSharedSourceDir ? ['sync_download.py', '__pycache__'] : []
@@ -860,7 +875,22 @@ function walkDir(dir, prefix = '') {
     const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
     if (isInternalSharedRelPath(relPath)) continue;
     const fullPath = path.join(dir, entry.name);
-    if (entry.isSymbolicLink()) continue;
+    if (entry.isSymbolicLink()) {
+      // 仅放行 sharedDir 顶层已登记的链接,其余符号链接照旧排除
+      if (prefix !== '') continue;
+      const linkTarget = getRegisteredLinkTarget(entry.name);
+      if (!linkTarget) continue;
+      const realLinkPath = getRealPathIfExists(fullPath);
+      if (!realLinkPath || !sharedLinks.isRealPathWithinTarget(realLinkPath, linkTarget)) continue;
+      const linkStat = fs.statSync(fullPath);
+      if (linkStat.isDirectory()) {
+        results.push({ name: relPath, type: 'dir', modified: linkStat.mtime.toISOString() });
+        results = results.concat(walkDir(fullPath, relPath));
+      } else if (linkStat.isFile()) {
+        results.push({ name: relPath, type: 'file', size: linkStat.size, modified: linkStat.mtime.toISOString() });
+      }
+      continue;
+    }
     const stat = fs.statSync(fullPath);
     if (entry.isDirectory()) {
       results.push({ name: relPath, type: 'dir', modified: stat.mtime.toISOString() });
@@ -883,7 +913,8 @@ function resolveSharedEntry(relPath) {
 
   const realSharedDir = getRealPathIfExists(sharedDir) || path.resolve(sharedDir);
   const realFullPath = getRealPathIfExists(fullPath);
-  if (realFullPath && !isPathInside(realSharedDir, realFullPath)) return null;
+  if (realFullPath && !isPathInside(realSharedDir, realFullPath)
+    && !isRegisteredLinkEscapeAllowed(normalized, realFullPath)) return null;
 
   return { relPath: normalized, fullPath: realFullPath || fullPath };
 }
@@ -1124,7 +1155,7 @@ app.post('/api/archive', requireDeviceAuth, async (req, res) => {
   activeDownloads++;
   streamEncryptedResponse({
     res,
-    sourceStream: tar.create({ gzip: true, cwd: sharedDir }, archive.paths),
+    sourceStream: tar.create({ gzip: true, follow: true, cwd: sharedDir }, archive.paths),
     label: 'ARCHIVE',
     extraHeaders: {
       'X-File-Name': encodeURIComponent('selected.tar.gz'),
@@ -1171,7 +1202,7 @@ app.get('/api/batch', requireDeviceAuth, (req, res) => {
   activeDownloads++;
   streamEncryptedResponse({
     res,
-    sourceStream: tar.create({ gzip: true, cwd: sharedDir }, files),
+    sourceStream: tar.create({ gzip: true, follow: true, cwd: sharedDir }, files),
     label: 'BATCH',
     extraHeaders: {
       'X-Batch-Count': String(files.length),

--- a/share.js
+++ b/share.js
@@ -37,6 +37,7 @@ const dataDir = resolveDataDir();
 const repoSharedSourceDir = path.resolve(path.join(__dirname, 'shared'));
 
 const storage = require('./lib/cloud-storage');
+const sharedLinks = require('./lib/shared-links');
 
 function loadMasterKey() {
   try {
@@ -137,6 +138,7 @@ if (args.length === 0) {
   const displayDir = path.relative(process.cwd(), sharedDir) || '.';
   console.log('用法:');
   console.log(`  node share.js file1.pdf dir/ file2.txt  — 复制到 ${displayDir}/`);
+  console.log(`  node share.js --link file1 dir/ ...     — 以符号链接挂到 ${displayDir}/(不复制、不上传云端)`);
   console.log('  node share.js --list                    — 列出共享文件');
   console.log(`  node share.js --clear                   — 清空 ${displayDir}/`);
   process.exit(0);
@@ -148,19 +150,40 @@ if (args[0] === '--list') {
     console.log(`${path.relative(process.cwd(), sharedDir) || '.'}/ 目录为空`);
     process.exit(0);
   }
+  const registry = sharedLinks.loadRegistry(dataDir);
   const walk = (dir, prefix = '') => {
     for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
       if (e.name.startsWith('.')) continue;
       const rel = prefix ? `${prefix}/${e.name}` : e.name;
       if (isHiddenSharedRelPath(rel)) continue;
+      const full = path.join(dir, e.name);
       if (e.isSymbolicLink()) {
-        console.warn(`  跳过符号链接: ${rel}`);
+        // 顶层已登记链接正常显示并跟随,其余符号链接保持跳过
+        const target = prefix === '' ? sharedLinks.getRegisteredTarget(registry, e.name) : null;
+        if (!target) {
+          console.warn(`  跳过符号链接: ${rel}`);
+          continue;
+        }
+        let linkStat = null;
+        try {
+          linkStat = fs.statSync(full);
+        } catch {
+          linkStat = null;
+        }
+        if (linkStat && linkStat.isDirectory()) {
+          console.log(`  ${rel} -> ${target} (链接)`);
+          walk(full, rel);
+        } else if (linkStat && linkStat.isFile()) {
+          console.log(`  ${rel} -> ${target} (链接, ${formatSize(linkStat.size)})`);
+        } else {
+          console.log(`  ${rel} -> ${target} (链接, 目标缺失)`);
+        }
         continue;
       }
       if (e.isDirectory()) {
-        walk(path.join(dir, e.name), rel);
+        walk(full, rel);
       } else {
-        const sz = fs.statSync(path.join(dir, e.name)).size;
+        const sz = fs.statSync(full).size;
         console.log(`  ${rel}  (${formatSize(sz)})`);
       }
     }
@@ -175,13 +198,88 @@ if (args[0] === '--clear') {
     for (const entry of fs.readdirSync(sharedDir, { withFileTypes: true })) {
       if (entry.name.startsWith('.')) continue;
       if (isProtectedSharedRelPath(entry.name)) continue;
+      // rmSync 作用于符号链接本身,不会跟随删除目标
       fs.rmSync(path.join(sharedDir, entry.name), { recursive: true, force: true });
     }
   }
   fs.mkdirSync(sharedDir, { recursive: true });
+  // 同步清空软链接登记文件
+  sharedLinks.saveRegistryAtomic(dataDir, {});
   scheduleCloudClear();
   console.log(`${path.relative(process.cwd(), sharedDir) || '.'}/ 已清空`);
   process.exit(0);
+}
+
+// --link: symlink external files/dirs into shared/ and register them
+if (args[0] === '--link') {
+  const sources = args.slice(1);
+  if (sources.length === 0) {
+    console.error('用法: node share.js --link <文件或目录> [更多路径...]');
+    process.exit(1);
+  }
+  fs.mkdirSync(sharedDir, { recursive: true });
+  const registry = sharedLinks.loadRegistry(dataDir);
+  let count = 0;
+  let failed = false;
+
+  for (const src of sources) {
+    const resolved = path.resolve(src);
+    if (!fs.existsSync(resolved)) {
+      console.error(`  跳过: ${src} (不存在)`);
+      continue;
+    }
+    const stat = fs.lstatSync(resolved);
+    if (stat.isSymbolicLink()) {
+      console.error(`  跳过: ${src} (源本身是符号链接,不允许共享)`);
+      continue;
+    }
+    const realTarget = fs.realpathSync(resolved);
+    const baseName = path.basename(resolved);
+    const dest = path.join(sharedDir, baseName);
+
+    let existing = null;
+    try {
+      existing = fs.lstatSync(dest);
+    } catch {
+      existing = null;
+    }
+    if (existing) {
+      console.error(`  跳过: ${baseName} (共享目录中已存在同名条目)`);
+      continue;
+    }
+
+    const isDir = stat.isDirectory();
+    // Windows 目录用 junction(无需管理员权限,要求绝对路径),文件用默认 symlink
+    const linkType = process.platform === 'win32'
+      ? (isDir ? 'junction' : 'file')
+      : (isDir ? 'dir' : 'file');
+    try {
+      fs.symlinkSync(realTarget, dest, linkType);
+    } catch (err) {
+      failed = true;
+      if (err && ['EPERM', 'EACCES', 'ENOTSUP'].includes(err.code)) {
+        console.error(`  失败: ${baseName} (创建符号链接被拒绝: ${err.code})`);
+        if (process.platform === 'win32' && !isDir) {
+          console.error('  提示: Windows 创建文件符号链接需要管理员权限或开发者模式,可改用复制模式: node share.js <文件>');
+        } else {
+          console.error('  提示: 当前环境不允许创建符号链接,可改用复制模式: node share.js <路径>');
+        }
+      } else {
+        console.error(`  失败: ${baseName} (${err && err.message ? err.message : err})`);
+      }
+      continue;
+    }
+
+    registry[baseName] = realTarget;
+    console.log(`  + ${baseName} -> ${realTarget} (链接)`);
+    count++;
+  }
+
+  if (count > 0) {
+    sharedLinks.saveRegistryAtomic(dataDir, registry);
+  }
+  console.log(`共创建 ${count} 个链接到 ${path.relative(process.cwd(), sharedDir) || '.'}/(链接项不调度云上传)`);
+  process.exit(failed ? 1 : 0);
 }
 
 // Copy files/dirs to shared/


### PR DESCRIPTION
## 概述

为 `share.js` 新增 `--link` 模式:以符号链接(而非复制)把外部文件/目录挂入 `shared/`,配套服务端白名单机制,仅放行显式登记过的链接穿透既有的 realpath 反目录穿越防护。

## 动机

复制模式对大文件/大目录既占磁盘又耗时;软链接模式零拷贝、即时生效。但服务端 `resolveSharedEntry()` 的 realpath 防护会拒绝一切逃出 `shared/` 的路径(安全设计,不能简单放开),因此引入 `data/shared-links.json` 显式授权清单:只有用户通过 `share.js --link` 登记过的目标才允许穿透,未登记符号链接行为完全不变。

## 改动

- **`lib/shared-links.js`(新增)**:白名单读写工具 —— 原子写(临时文件 + rename)、服务端 mtime 缓存读取、条目校验(key 仅限顶层 basename,value 必须是绝对 realpath)、跨平台路径比较(win32 大小写不敏感)
- **`share.js`**:`--link <路径...>` 创建符号链接并登记(不复制、不调度云上传);`--list` 显示 `名字 -> 目标 (链接)`;`--clear` 同步清空登记文件
- **`server.js`**:`resolveSharedEntry` 仅当路径第一段是已登记链接名且 realpath 在登记目标内时放行越界;`walkDir` 只展示已登记顶层链接;`tar.create` 增加 `follow: true`(`containsSymlink` 拦截不变,未登记/嵌套符号链接仍会导致打包被拒,不会泄露内容)
- **`scripts/integration-test.js`**:已登记链接可列出/下载/打包;未登记链接不可见且下载被拒;符号链接创建不可用时用例 skip 而非 fail
- **`README.md` / `AGENTS.md`**:用法与模块说明同步更新

## 跨平台兼容

- Windows 目录链接使用 `junction`(无需管理员权限,要求绝对路径——登记的本来就是 realpath);Windows 文件链接遇 `EPERM`/`EACCES`/`ENOTSUP` 给出中文提示(需管理员权限或开发者模式),建议改用复制模式
- Linux/macOS 使用标准 `dir`/`file` 类型符号链接
- 所有路径比较先 `realpath` 规范化,win32 下统一小写

## 测试

- `npm test`(smoke + integration)通过,链接用例真实执行(非 skip)
- 手动验证 `--link` / `--list` / `--clear` 行为符合预期